### PR TITLE
fix invalid doctor index when adding new appointment

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAppointmentCommand.java
@@ -71,8 +71,8 @@ public class AddAppointmentCommand extends Command {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        if (doctorIndex.getZeroBased() > lastDoctorList.size()) {
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        if (doctorIndex.getZeroBased() >= lastDoctorList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_DOCTOR_DISPLAYED_INDEX);
         }
 
         Person targetPatient = lastShownList.get(targetIndex.getZeroBased());


### PR DESCRIPTION
now displays correct error for invalid doctor index when trying to add new appointment

as per #164 